### PR TITLE
feat!: replace `config:environment` lookup with `setConfig` function

### DIFF
--- a/docs-app/app/app.ts
+++ b/docs-app/app/app.ts
@@ -2,6 +2,7 @@ import Application from '@ember/application';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from 'docs-app/config/environment';
+import { setConfig } from 'ember-shiki';
 
 import './assets/app.css';
 
@@ -12,3 +13,7 @@ export default class App extends Application {
 }
 
 loadInitializers(App, config.modulePrefix);
+
+setConfig({
+  defaultThemes: ['github-dark'],
+});

--- a/docs-app/app/controllers/application.ts
+++ b/docs-app/app/controllers/application.ts
@@ -63,16 +63,24 @@ export default class CopyToClipboard extends Component {
   </template>
 }`;
 
-  setupConfigCode = `module.exports = function (environment) {
-  const ENV = {
-    // ...
-    'ember-shiki': {
-      defaultLanguages: ['gjs', 'gts', 'css'],
-      defaultThemes: ['github-dark'],
-    },
-  };
-  // ...
-};`;
+  setupConfigCode = `import Application from '@ember/application';
+import Resolver from 'ember-resolver';
+import loadInitializers from 'ember-load-initializers';
+import config from 'my-app/config/environment';
+import { setConfig } from 'ember-shiki';
+
+export default class App extends Application {
+  modulePrefix = config.modulePrefix;
+  podModulePrefix = config.podModulePrefix;
+  Resolver = Resolver;
+}
+
+loadInitializers(App, config.modulePrefix);
+
+setConfig({
+  defaultLanguages: ['gjs', 'gts', 'css'],
+  defaultThemes: ['github-dark'],
+})`;
 
   lineNumbersCode = `<CodeBlock
   @code="// Line numbers!

--- a/docs-app/app/templates/application.hbs
+++ b/docs-app/app/templates/application.hbs
@@ -137,22 +137,25 @@
         <InlineCode>nord</InlineCode>
         theme by default if no theme is specified. This docs website uses
         <InlineCode>github-dark</InlineCode>.</p>
-      <p>The global defaults can be adjusted in the
-        <InlineCode>environment.js</InlineCode>
+      <p>The global defaults can be adjusted using
+        <InlineCode>setConfig</InlineCode>
         file by adding an entry for
         <InlineCode>ember-shiki</InlineCode>.</p>
 
       <CodeBlock
         @code={{this.setupConfigCode}}
         @language="js"
-        @name="app/config/environment.js"
-        @lineHighlights={{array (hash start=4 end=7 type="add")}}
+        @name="app/app.js"
+        @lineHighlights={{array
+          (hash start=5 type="add")
+          (hash start=15 end=18 type="add")
+        }}
       />
       <p>Shiki languages, themes, and WASM are loaded from a CDN by default. If
         you wish to change the CDN, or self-host these resources, you can set a
         custom
         <InlineCode>cdnUrl</InlineCode>
-        in the environment config.</p>
+        in the config.</p>
 
       <hr class="my-16 h-px border-0 bg-gray-700" />
 

--- a/docs-app/app/templates/application.hbs
+++ b/docs-app/app/templates/application.hbs
@@ -139,7 +139,7 @@
         <InlineCode>github-dark</InlineCode>.</p>
       <p>The global defaults can be adjusted using
         <InlineCode>setConfig</InlineCode>
-        file by adding an entry for
+        imported from
         <InlineCode>ember-shiki</InlineCode>.</p>
 
       <CodeBlock

--- a/docs-app/config/environment.js
+++ b/docs-app/config/environment.js
@@ -13,9 +13,6 @@ module.exports = function (environment) {
         // e.g. EMBER_NATIVE_DECORATOR_SUPPORT: true
       },
     },
-    'ember-shiki': {
-      defaultThemes: ['github-dark'],
-    },
 
     APP: {
       // Here you can pass flags/options to your application instance

--- a/ember-shiki/src/components/code-block.ts
+++ b/ember-shiki/src/components/code-block.ts
@@ -6,6 +6,7 @@ import { tracked } from '@glimmer/tracking';
 import ShikiService from '../services/shiki';
 import { Lang, Theme } from 'shiki';
 import { SafeString, htmlSafe } from '@ember/template';
+import { config } from '../index.ts';
 
 import '../styles.css';
 
@@ -83,13 +84,7 @@ export default class CodeBlock extends Component<CodeBlockSignature> {
       return this.args.showLineNumbers;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const config: any = (
-      getOwner(this) as ApplicationInstance
-    )?.resolveRegistration('config:environment');
-    const { showLineNumbers }: { showLineNumbers?: boolean } =
-      config['ember-shiki'] ?? {};
-
+    const { showLineNumbers } = config;
     return showLineNumbers ?? false;
   }
 
@@ -98,13 +93,7 @@ export default class CodeBlock extends Component<CodeBlockSignature> {
       return this.args.showCopyButton;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const config: any = (
-      getOwner(this) as ApplicationInstance
-    )?.resolveRegistration('config:environment');
-    const { showCopyButton }: { showCopyButton?: boolean } =
-      config['ember-shiki'] ?? {};
-
+    const { showCopyButton } = config;
     return showCopyButton ?? true;
   }
 

--- a/ember-shiki/src/index.ts
+++ b/ember-shiki/src/index.ts
@@ -1,4 +1,22 @@
+import type { Lang, Theme } from 'shiki';
+
+interface Config {
+  defaultLanguages?: Lang[];
+  defaultThemes?: Theme[];
+  showLineNumbers?: boolean;
+  showCopyButton?: boolean;
+  cdnUrl?: string;
+}
+
 export { default as ShikiService } from './services/shiki.ts';
 export { default as CodeGroup } from './components/code-group.ts';
 export { default as CodeTab } from './components/code-tab.ts';
 export { default as CodeBlock } from './components/code-block.ts';
+
+let _config: Config = {};
+
+export function setConfig(config: Config) {
+  _config = config;
+}
+
+export { _config as config };

--- a/ember-shiki/src/services/shiki.ts
+++ b/ember-shiki/src/services/shiki.ts
@@ -12,6 +12,7 @@ import { task } from 'ember-concurrency';
 import ApplicationInstance from '@ember/application/instance';
 import { tracked } from '@glimmer/tracking';
 import { LineHighlight } from '../components/code-block';
+import { config } from '../index.ts';
 
 export default class ShikiService extends Service {
   @tracked isInitialized = false;
@@ -67,11 +68,7 @@ export default class ShikiService extends Service {
   });
 
   get cdnUrl() {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const config: any = (
-      getOwner(this) as ApplicationInstance
-    )?.resolveRegistration('config:environment');
-    const { cdnUrl } = config['ember-shiki'] ?? {};
+    const { cdnUrl } = config;
     if (cdnUrl) {
       return cdnUrl;
     }
@@ -84,11 +81,7 @@ export default class ShikiService extends Service {
       return;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const config: any = (
-      getOwner(this) as ApplicationInstance
-    )?.resolveRegistration('config:environment');
-    const { defaultLanguages, defaultThemes } = config['ember-shiki'] ?? {};
+    const { defaultLanguages, defaultThemes } = config;
 
     const {
       BUNDLED_LANGUAGES,

--- a/test-app/app/app.ts
+++ b/test-app/app/app.ts
@@ -2,6 +2,7 @@ import Application from '@ember/application';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from 'test-app/config/environment';
+import { setConfig } from 'ember-shiki';
 
 export default class App extends Application {
   modulePrefix = config.modulePrefix;
@@ -10,3 +11,10 @@ export default class App extends Application {
 }
 
 loadInitializers(App, config.modulePrefix);
+
+setConfig({
+  defaultLanguages: ['gjs', 'gts', 'sh', 'css'],
+  defaultThemes: ['material-theme-palenight'],
+  showLineNumbers: false,
+  // cdnUrl: 'https://localhost:4200/',
+});

--- a/test-app/config/environment.js
+++ b/test-app/config/environment.js
@@ -18,12 +18,6 @@ module.exports = function (environment) {
       // Here you can pass flags/options to your application instance
       // when it is created
     },
-    'ember-shiki': {
-      defaultLanguages: ['gjs', 'gts', 'sh', 'css'],
-      defaultThemes: ['material-theme-palenight'],
-      showLineNumbers: false,
-      // cdnUrl: 'https://localhost:4200/',
-    },
   };
 
   if (environment === 'development') {


### PR DESCRIPTION
The `config/environment.js` file is not guaranteed to exist in non-compat Ember apps. Propose exporting a `setConfig` function that can be called from `app/app.js` to set global config.

Context: https://discord.com/channels/480462759797063690/568935504288940056/1440849225960394763